### PR TITLE
fix-issue-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
     "url": "https://github.com/bmstu-iu9/utp2020-11-spreadsheet/issues"
   },
   "homepage": "https://github.com/bmstu-iu9/utp2020-11-spreadsheet#readme",
-  "dependencies": {
-    "jsonschema": "^1.2.6",
-    "mock-fs": "^4.12.0"
-  },
+  "dependencies": {},
   "type": "module",
   "devDependencies": {
     "c8": "^7.2.0",
@@ -30,6 +27,8 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
     "mocha": "^8.0.1",
-    "util.promisify": "^1.0.1"
+    "util.promisify": "^1.0.1",
+    "jsonschema": "^1.2.6",
+    "mock-fs": "^4.12.0"
   }
 }

--- a/src/lib/saveWorkbook/ClassConverter.js
+++ b/src/lib/saveWorkbook/ClassConverter.js
@@ -30,9 +30,7 @@ export default class ClassConverter {
 
   static saveJson(userWorkbook, pathToWorkbooks) {
     const file = this.convertToJson(userWorkbook);
-    if (!fs.existsSync(`${pathToWorkbooks}`)) {
-      fs.mkdirSync(`${pathToWorkbooks}`, true);
-    }
+    fs.mkdirSync(pathToWorkbooks, true);
     fs.writeFileSync(`${pathToWorkbooks}/${userWorkbook.name}.json`, file);
   }
 }

--- a/src/lib/saveWorkbook/ClassConverter.js
+++ b/src/lib/saveWorkbook/ClassConverter.js
@@ -30,18 +30,8 @@ export default class ClassConverter {
 
   static saveJson(userWorkbook, pathToWorkbooks) {
     const file = this.convertToJson(userWorkbook);
-    const directories = pathToWorkbooks.split('/');
-    let checkPath = false;
-    directories.forEach((dir) => {
-      if (dir === 'workbooks') {
-        checkPath = true;
-      }
-    });
-    if (checkPath === false) {
-      throw new Error('Incorrect path to workbooks');
-    }
     if (!fs.existsSync(`${pathToWorkbooks}`)) {
-      fs.mkdirSync(`${pathToWorkbooks}`);
+      fs.mkdirSync(`${pathToWorkbooks}`, true);
     }
     fs.writeFileSync(`${pathToWorkbooks}/${userWorkbook.name}.json`, file);
   }

--- a/src/lib/saveWorkbook/ClassConverter.js
+++ b/src/lib/saveWorkbook/ClassConverter.js
@@ -28,12 +28,21 @@ export default class ClassConverter {
     return JSON.stringify(jsonWorkbook);
   }
 
-  static saveJson(userName, userWorkbook, pathToWorkbooks = '.') {
+  static saveJson(userWorkbook, pathToWorkbooks) {
     const file = this.convertToJson(userWorkbook);
-    if (!fs.existsSync(`${pathToWorkbooks}/${userName}`)) {
-      fs.mkdirSync(`${pathToWorkbooks}/${userName}`);
+    const directories = pathToWorkbooks.split('/');
+    let checkPath = false;
+    directories.forEach((dir) => {
+      if (dir === 'workbooks') {
+        checkPath = true;
+      }
+    });
+    if (checkPath === false) {
+      throw new Error('Incorrect path to workbooks');
     }
-    fs.writeFileSync(`${pathToWorkbooks}/${userName}/${userWorkbook.name}.json`, file);
-    return true;
+    if (!fs.existsSync(`${pathToWorkbooks}`)) {
+      fs.mkdirSync(`${pathToWorkbooks}`);
+    }
+    fs.writeFileSync(`${pathToWorkbooks}/${userWorkbook.name}.json`, file);
   }
 }

--- a/src/tests/lib/saveWorkbook/ClassConverter.test.js
+++ b/src/tests/lib/saveWorkbook/ClassConverter.test.js
@@ -12,7 +12,7 @@ import {
 
 const workbookStandardName = 'workbook';
 const spreadsheetStandardName = 'spreadsheet';
-const userStandartName = 'alexis';
+const pathToWorkbooks = '~/workbooks/alexis';
 const tableSchema = JSON.parse(fs.readFileSync('./resources/tableSchema.json'));
 
 describe('ClassConverter', () => {
@@ -42,7 +42,8 @@ describe('ClassConverter', () => {
       mock({
         '~/workbooks': {},
       });
-      assert.strictEqual(ClassConverter.saveJson(userStandartName, workbook, '~/workbooks'), true);
+      ClassConverter.saveJson(workbook, pathToWorkbooks);
+      assert.strictEqual(fs.existsSync(`${pathToWorkbooks}/${workbookStandardName}.json`), true);
       mock.restore();
     });
     it('should throw an exception for incorrect path to workbooks', () => {
@@ -52,7 +53,7 @@ describe('ClassConverter', () => {
         '~/workbooks': {},
       });
       assert.throws(() => {
-        ClassConverter.saveJson(userStandartName, workbook, '~/src');
+        ClassConverter.saveJson(workbook, '~/src');
       });
       mock.restore();
     });
@@ -66,7 +67,7 @@ describe('ClassConverter', () => {
         }),
       });
       assert.throws(() => {
-        ClassConverter.saveJson(userStandartName, workbook, '~/workbooks');
+        ClassConverter.saveJson(workbook, pathToWorkbooks);
       });
       mock.restore();
     });

--- a/src/tests/lib/saveWorkbook/ClassConverter.test.js
+++ b/src/tests/lib/saveWorkbook/ClassConverter.test.js
@@ -46,17 +46,6 @@ describe('ClassConverter', () => {
       assert.strictEqual(fs.existsSync(`${pathToWorkbooks}/${workbookStandardName}.json`), true);
       mock.restore();
     });
-    it('should throw an exception for incorrect path to workbooks', () => {
-      const spreadsheets = [new Spreadsheet(spreadsheetStandardName)];
-      const workbook = new Workbook(workbookStandardName, spreadsheets);
-      mock({
-        '~/workbooks': {},
-      });
-      assert.throws(() => {
-        ClassConverter.saveJson(workbook, '~/src');
-      });
-      mock.restore();
-    });
     it('should throw an exeption for creating file without permission', () => {
       const spreadsheets = [new Spreadsheet(spreadsheetStandardName)];
       const workbook = new Workbook(workbookStandardName, spreadsheets);


### PR DESCRIPTION
- Необходимые зависимости были перенесены в `devDependencies`
- Классу конвертации книг в JSON теперь необходимо передавать только саму книгу и путь до папки назначения (ранее было необходимо передать еще и имя пользователя)
- Исправлен тест на корректное создание json-файла: теперь проверяется наличие данного файла по задонному пути с помощью модуля fs, а не возвращаемое значение `true` из функции сохранения книги в json-файл