### PR TITLE
Remove deprecated methods

### DIFF
--- a/src/tests/lib/calculator/Calculator.test.js
+++ b/src/tests/lib/calculator/Calculator.test.js
@@ -3,13 +3,13 @@ import Calculator from '../../../lib/calculator/Calculator.js';
 import Workbook from '../../../lib/spreadsheets/Workbook.js';
 import Spreadsheet from '../../../lib/spreadsheets/Spreadsheet.js';
 import { Cell, valueTypes } from '../../../lib/spreadsheets/Cell.js';
+import NumberType from '../../../lib/typevalue/NumberType.js';
 
 describe('Calculator', () => {
   describe('#constructor()', () => {
     it('should make new element', () => {
-      assert.deepEqual(new Calculator(new Workbook('book')), { book: new Workbook('book') });
-      assert.deepEqual(new Calculator(new Workbook('fdsfdg')), { book: new Workbook('fdsfdg') });
-      assert.deepEqual(new Calculator(new Workbook('2635fg')), { book: new Workbook('2635fg') });
+      const calculator = new Calculator(new Workbook('book'));
+      assert.deepStrictEqual(calculator.book, new Workbook('book'));
     });
   });
   describe('#calculate()', () => {
@@ -18,8 +18,7 @@ describe('Calculator', () => {
       cells.set('A1', new Cell(valueTypes.formula, '=(1+5^(1/2))/2'));
       const spreadsheet = new Spreadsheet('table', cells);
       const wb = new Workbook('book', [spreadsheet]);
-
-      assert.deepEqual(new Calculator(wb).calculate('A1', 0), { value: (1 + Math.sqrt(5)) / 2 });
+      assert.deepStrictEqual(new Calculator(wb).calculate('A1', 0), new NumberType((1 + Math.sqrt(5)) / 2));
     });
   });
 });

--- a/src/tests/lib/calculator/Calculator.test.js
+++ b/src/tests/lib/calculator/Calculator.test.js
@@ -5,11 +5,12 @@ import Spreadsheet from '../../../lib/spreadsheets/Spreadsheet.js';
 import { Cell, valueTypes } from '../../../lib/spreadsheets/Cell.js';
 import NumberType from '../../../lib/typevalue/NumberType.js';
 
+const book = new Workbook('book');
 describe('Calculator', () => {
   describe('#constructor()', () => {
     it('should make new element', () => {
-      const calculator = new Calculator(new Workbook('book'));
-      assert.deepStrictEqual(calculator.book, new Workbook('book'));
+      const calculator = new Calculator(book);
+      assert.deepStrictEqual(calculator.book, book);
     });
   });
   describe('#calculate()', () => {

--- a/src/tests/lib/calculator/TreeRunner.test.js
+++ b/src/tests/lib/calculator/TreeRunner.test.js
@@ -1,149 +1,295 @@
+/* eslint-disable no-self-compare */
 import * as assert from 'assert';
-import TR from '../../../lib/calculator/TreeRunner.js';
-import WB from '../../../lib/spreadsheets/Workbook.js';
+import TreeRunner from '../../../lib/calculator/TreeRunner.js';
+import Workbook from '../../../lib/spreadsheets/Workbook.js';
 import Parser from '../../../lib/parser/Parser.js';
 
+const book = new Workbook('book');
 describe('TreeRunner', () => {
   describe('#constructor()', () => {
-    it('should make new element', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=(1+5^(1/2))/2').run()),
-        { book: new WB('book'), page: 0, tree: new Parser('=(1+5^(1/2))/2').run() });
-      assert.deepEqual(new TR(new WB('asdff'), 1344, new Parser('=1+1').run()),
-        { book: new WB('asdff'), page: 1344, tree: new Parser('=1+1').run() });
+    it('Should make new element', () => {
+      const tree = new Parser('=(1+5^(1/2))/2').run();
+      const treeRunner = new TreeRunner(book, 0, tree);
+      assert.strictEqual(treeRunner.book, book);
+      assert.strictEqual(treeRunner.page, 0);
+      assert.strictEqual(treeRunner.tree, tree);
     });
   });
   describe('#makeTreeRunner()', () => {
-    it('should derive new element', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=(1+5^(1/2))/2').run()).makeTreeRunner(new Parser('=1+1').run()),
-        { book: new WB('book'), page: 0, tree: new Parser('=1+1').run() });
-      assert.deepEqual(new TR(new WB('asdff'), 1344, new Parser('=1+1').run()).makeTreeRunner(new Parser('=(1+5^(1/2))/2').run()),
-        { book: new WB('asdff'), page: 1344, tree: new Parser('=(1+5^(1/2))/2').run() });
+    it('Should derive new element', () => {
+      const tree = new Parser('=(1+5^(1/2))/2').run();
+      const treeRunner = new TreeRunner(book, 0, null);
+      const newTreeRunner = treeRunner.makeTreeRunner(tree);
+      assert.strictEqual(newTreeRunner.book, book);
+      assert.strictEqual(newTreeRunner.page, 0);
+      assert.strictEqual(newTreeRunner.tree, tree);
     });
   });
   describe('#run()', () => {
-    it('should calculate invalid expression', () => {
+    it('Should throw error because of invalid expression', () => {
       assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=СТРАННАЯФУНКЦИЯ(0/0;2;"a"/5)').run()).run();
+        new TreeRunner(book, 0, new Parser('=СТРАННАЯФУНКЦИЯ(0/0;2;"a"/5)').run()).run();
       });
     });
-    it('should calculate integer', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=10').run()).run(), { value: 10 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=1241532').run()).run(), { value: 1241532 });
-    });
-    it('should calculate string', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="akshdj"').run()).run(), { value: 'akshdj' });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="9a8oe7hytviyf"').run()).run(), { value: '9a8oe7hytviyf' });
-    });
-    it('should calculate value', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('askd ;j mfa,F:m;').run()).run(), { value: 'askd ;j mfa,F:m;' });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('456789876').run()).run(), { value: '456789876' });
-    });
-    it('should calculate sum()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324+92380').run()).run(), { value: 324 + 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg"+"lkas"').run()).run(), { value: 'asdfglkas' });
-    });
-    it('should calculate sub()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324-92380').run()).run(), { value: 324 - 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=79883-9783').run()).run(), { value: 79883 - 9783 });
-    });
-    it('should calculate mul()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324*92380').run()).run(), { value: 324 * 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=79883*9783').run()).run(), { value: 79883 * 9783 });
-    });
-    it('should calculate div()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324/92380').run()).run(), { value: 324 / 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=79883/9783').run()).run(), { value: 79883 / 9783 });
-    });
-    it('should calculate rem()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324%92380').run()).run(), { value: 324 % 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=79883%9783').run()).run(), { value: 79883 % 9783 });
-    });
-    it('should calculate exp()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=324^92380').run()).run(), { value: 324 ** 92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=79883^9783').run()).run(), { value: 79883 ** 9783 });
-    });
-    it('should calculate unMinus()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=-92380').run()).run(), { value: -92380 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=-9783').run()).run(), { value: -9783 });
-    });
-    it('should calculate equal()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3==4').run()).run(), { value: 3 === 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4==4').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5==4').run()).run(), { value: 5 === 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg"=="lkas"').run()).run(), { value: 'asdfg' === 'lkas' });
-    });
-    it('should calculate greaterEqual()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3>=4').run()).run(), { value: 3 >= 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4>=4').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5>=4').run()).run(), { value: 5 >= 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg">="lkas"').run()).run(), { value: 'asdfg' >= 'lkas' });
-    });
-    it('should calculate greater()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3>4').run()).run(), { value: 3 > 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4>4').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5>4').run()).run(), { value: 5 > 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg">"lkas"').run()).run(), { value: 'asdfg' > 'lkas' });
-    });
-    it('should calculate lessEqual()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3<=4').run()).run(), { value: 3 <= 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4<=4').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5<=4').run()).run(), { value: 5 <= 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg"<="lkas"').run()).run(), { value: 'asdfg' <= 'lkas' });
-    });
-    it('should calculate less()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3<4').run()).run(), { value: 3 < 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4<4').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5<4').run()).run(), { value: 5 < 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg"<"lkas"').run()).run(), { value: 'asdfg' < 'lkas' });
-    });
-    it('should calculate notEqual()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=3!=4').run()).run(), { value: 3 !== 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=4!=4').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=5!=4').run()).run(), { value: 5 !== 4 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('="asdfg"!="lkas"').run()).run(), { value: 'asdfg' !== 'lkas' });
-    });
-    it('should calculate И()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=И()').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=И(1==1;5/2==10/4)').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=И(1==1;5/2==10/3)').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=И(1==5;5/2==10/4)').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=И(1==5;"gregdfsg")').run()).run(), { value: false });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=И(1==1;"gregdfsg")').run()).run();
+    const testCasesWithoutError = [{
+      description: 'Should calculate integer',
+      parserExpression: '=10',
+      result: 10,
+    },
+    {
+      description: 'Should calculate string',
+      parserExpression: '="string"',
+      result: 'string',
+    },
+    {
+      description: 'Should calculate value in number form',
+      parserExpression: 'askd ;j mfa,F:m;',
+      result: 'askd ;j mfa,F:m;',
+    },
+    {
+      description: 'Should calculate value in other form',
+      parserExpression: '456789876',
+      result: 456789876,
+    },
+    {
+      description: 'Should calculate sum() of two numbers',
+      parserExpression: '=10+100',
+      result: 110,
+    },
+    {
+      description: 'Should calculate sum() of two strings',
+      parserExpression: '="str"+"ing"',
+      result: 'string',
+    },
+    {
+      description: 'Should calculate sub() of two numbers',
+      parserExpression: '=100-90',
+      result: 10,
+    },
+    {
+      description: 'Should calculate mul() of two numbers',
+      parserExpression: '=10*100',
+      result: 1000,
+    },
+    {
+      description: 'Should calculate div() of two numbers',
+      parserExpression: '=100/10',
+      result: 100 / 10,
+    },
+    {
+      description: 'Should calculate rem()',
+      parserExpression: '=50%3',
+      result: 50 % 3,
+    },
+    {
+      description: 'Should calculate exp()',
+      parserExpression: '=2^3',
+      result: 2 ** 3,
+    },
+    {
+      description: 'Should calculate unMinus()',
+      parserExpression: '=-10',
+      result: -10,
+    },
+    {
+      description: 'Should calculate equal() different numbers',
+      parserExpression: '=3==4',
+      result: 3 === 4,
+    },
+    {
+      description: 'Should calculate equal() equal numbers',
+      parserExpression: '=4==4',
+      result: 4 === 4,
+    },
+    {
+      description: 'Should calculate equal() different strings',
+      parserExpression: '="abc"=="abcd"',
+      result: 'abc' === 'abcd',
+    },
+    {
+      description: 'Should calculate equal() equal strings',
+      parserExpression: '="abc"=="abc"',
+      result: 'abc' === 'abc',
+    },
+    {
+      description: 'Should calculate greaterEqual() with not equal numbers',
+      parserExpression: '=3>=4',
+      result: 3 >= 4,
+    },
+    {
+      description: 'Should calculate greaterEqual() with equal numbers',
+      parserExpression: '=4>=4',
+      result: 4 >= 4,
+    },
+    {
+      description: 'Should calculate greaterEqual() with not equal strings',
+      parserExpression: '="abc">="abcd"',
+      result: 'abc' >= 'abcd',
+    },
+    {
+      description: 'Should calculate greaterEqual() with equal strings',
+      parserExpression: '="abc">="abc"',
+      result: 'abs' >= 'abs',
+    },
+    {
+      description: 'Should calculate greater with numbers',
+      parserExpression: '=3>4',
+      result: 3 > 4,
+    },
+    {
+      description: 'Should calculate greater with strings',
+      parserExpression: '="abcd">"abc"',
+      result: 'abcd' > 'abc',
+    },
+    {
+      description: 'Should calculate lessEqual() with not equal numbers',
+      parserExpression: '=3<=4',
+      result: 3 <= 4,
+    },
+    {
+      description: 'Should calculate lessEqual() with equal numbers',
+      parserExpression: '=4<=4',
+      result: 4 <= 4,
+    },
+    {
+      description: 'Should calculate lessEqual() with not equal strings',
+      parserExpression: '="abc"<="abcd"',
+      result: 'abc' <= 'abcd',
+    },
+    {
+      description: 'Should calculate lessEqual() with equal strings',
+      parserExpression: '="abc"<="abc"',
+      result: 'abs' <= 'abs',
+    },
+    {
+      description: 'Should calculate less with numbers',
+      parserExpression: '=3<4',
+      result: 3 < 4,
+    },
+    {
+      description: 'Should calculate less with strings',
+      parserExpression: '="abcd"<"abc"',
+      result: 'abcd' < 'abc',
+    },
+    {
+      description: 'Should calculate notEqual() different numbers',
+      parserExpression: '=3!=4',
+      result: 3 !== 4,
+    },
+    {
+      description: 'Should calculate notEqual() equal numbers',
+      parserExpression: '=4!=4',
+      result: 4 !== 4,
+    },
+    {
+      description: 'Should calculate notEqual() different strings',
+      parserExpression: '="abc"!="abcd"',
+      result: 'abc' !== 'abcd',
+    },
+    {
+      description: 'Should calculate notEqual() equal strings',
+      parserExpression: '="abc"!="abc"',
+      result: 'abc' !== 'abc',
+    },
+    {
+      description: 'Should calculate И() without expressions',
+      parserExpression: '=И()',
+      result: true,
+    },
+    {
+      description: 'Should calculate И() with true expressions',
+      parserExpression: '=И(1==1;2==2)',
+      result: 1 === 1 && 2 === 2,
+    },
+    {
+      description: 'Should calculate И() with one true and one false expressions',
+      parserExpression: '=И(1==1;2==1)',
+      result: 1 === 1 && 2 === 1,
+    },
+    {
+      description: 'Should calculate И() with false expressions',
+      parserExpression: '=И(1==2;1==3)',
+      result: 1 === 2 && 1 === 3,
+    },
+    {
+      description: 'Should calculate И() with false expression and not boolean expression',
+      parserExpression: '=И(1==5;"gregdfsg")',
+      result: false,
+    },
+    {
+      description: 'Should calculate ИЛИ() without expressions',
+      parserExpression: '=ИЛИ()',
+      result: false,
+    },
+    {
+      description: 'Should calculate ИЛИ() with two true expressions',
+      parserExpression: '=ИЛИ(1==1;2==2)',
+      result: 1 === 1 || 2 === 2,
+    },
+    {
+      description: 'Should calculate ИЛИ() with two false expressions',
+      parserExpression: '=ИЛИ(1==2;2==3)',
+      result: 1 === 2 || 2 === 3,
+    },
+    {
+      description: 'Should calculate ИЛИ() with one false and one true expressions',
+      parserExpression: '=ИЛИ(1==1;1==2)',
+      result: 1 === 1 || 1 === 2,
+    },
+    {
+      description: 'Should calculate ИЛИ() with true expression and not boolean expression',
+      parserExpression: '=ИЛИ(1==1;"string")',
+      result: true,
+    },
+    {
+      description: 'Should calculate ЕСЛИ() with true expression',
+      parserExpression: '=ЕСЛИ(1==1;1;2)',
+      result: 1,
+    },
+    {
+      description: 'Should calculate ЕСЛИ() with false expression',
+      parserExpression: '=ЕСЛИ(1==2;1;2)',
+      result: 2,
+    },
+    {
+      description: 'Should calculate ЕСЛИ() with true expression and error in another branch',
+      parserExpression: '=ЕСЛИ(1==1;1;"string"*2)',
+      result: 1,
+    },
+    ];
+    testCasesWithoutError.forEach((testCase) => {
+      it(testCase.description, () => {
+        const tree = new Parser(testCase.parserExpression).run();
+        const treeRunner = new TreeRunner(book, 0, tree);
+        assert.strictEqual(treeRunner.run().value, testCase.result);
       });
     });
-    it('should calculate ИЛИ()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ИЛИ()').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ИЛИ(1==1;5/2==10/4)').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ИЛИ(1==5;5/2==10/4)').run()).run(), { value: true });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ИЛИ(1==5;5/2==10/3)').run()).run(), { value: false });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ИЛИ(1==1;"gregdfsg")').run()).run(), { value: true });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ИЛИ(1==5;"gregdfsg")').run()).run();
-      });
-    });
-    it('should calculate ЕСЛИ()', () => {
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==1;1;2)').run()).run(), { value: 1 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==5;1;2)').run()).run(), { value: 2 });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==1;"true";"gregdfsg"*8)').run()).run(), { value: 'true' });
-      assert.deepEqual(new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==5;"gregdfsg"*8;"false")').run()).run(), { value: 'false' });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ()').run()).run();
-      });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1;2)').run()).run();
-      });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1;2;3)').run()).run();
-      });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1;2;3;4)').run()).run();
-      });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==5;"true";"gregdfsg"*8)').run()).run();
-      });
-      assert.throws(() => {
-        new TR(new WB('book'), 0, new Parser('=ЕСЛИ(1==1;"gregdfsg"*8;"false")').run()).run();
+    const testCasesWithError = [{
+      description: 'Should throw error in И() because an invalid expression started evaluating',
+      parserExpression: '=И(1==1;"string")',
+    },
+    {
+      description: 'Should throw error in ИЛИ() because an invalid expression started evaluating',
+      parserExpression: '=ИЛИ(1==5;"string")',
+    },
+    {
+      description: 'Should throw error in ЕСЛИ() because has zero arguments',
+      parserExpression: '=ЕСЛИ()',
+    },
+    {
+      description: 'Should throw error in ЕСЛИ() because an invalid syntax',
+      parserExpression: '=ЕСЛИ(1;2;3)',
+    },
+    {
+      description: 'Should throw error in ЕСЛИ() because an invalid expression started evaluating',
+      parserExpression: '=ЕСЛИ(1==1;"string"*2;"false")',
+    },
+    ];
+    testCasesWithError.forEach((testCase) => {
+      it(testCase.description, () => {
+        const tree = new Parser(testCase.parserExpression).run();
+        const treeRunner = new TreeRunner(book, 0, tree);
+        assert.throws(() => treeRunner.run());
       });
     });
   });

--- a/src/tests/lib/calculator/TreeRunner.test.js
+++ b/src/tests/lib/calculator/TreeRunner.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-self-compare */
+// self-comparison is necessary to check the comparison function
 import * as assert from 'assert';
 import TreeRunner from '../../../lib/calculator/TreeRunner.js';
 import Workbook from '../../../lib/spreadsheets/Workbook.js';

--- a/src/tests/lib/filters/ColorFilter.test.js
+++ b/src/tests/lib/filters/ColorFilter.test.js
@@ -35,14 +35,14 @@ describe('ColorFilter', () => {
       const cell = new Cell();
       cell.setColor('#bbbbbb');
       const doesMatch = colorFilter.doesCellMatch(cell);
-      assert.equal(doesMatch, true);
+      assert.strictEqual(doesMatch, true);
     });
     it('should not match cell with color #bbbbbb for colors []', () => {
       const colorFilter = new ColorFilter('A', []);
       const cell = new Cell();
       cell.setColor('#bbbbbb');
       const doesMatch = colorFilter.doesCellMatch(cell);
-      assert.equal(doesMatch, false);
+      assert.strictEqual(doesMatch, false);
     });
   });
   describe('#run()', () => {
@@ -59,7 +59,7 @@ describe('ColorFilter', () => {
       ])];
       const colorFilter = new ColorFilter('AA', ['#aaaaaa']);
       const filtered = colorFilter.run(cells);
-      assert.deepEqual(filtered, [cells[0], cells[1]]);
+      assert.deepStrictEqual(filtered, [cells[0], cells[1]]);
     });
     it('should throw an exception for 2 cells in one position', () => {
       const cells = [new Map([

--- a/src/tests/lib/filters/ColumnFilter.test.js
+++ b/src/tests/lib/filters/ColumnFilter.test.js
@@ -27,15 +27,15 @@ describe('ColumnFilter', () => {
   describe('#doesPositionMatch()', () => {
     it('should match AB3 position for AB column', () => {
       const columnFilter = new ColumnFilter('AB');
-      assert.equal(columnFilter.doesPositionMatch('AB3'), true);
+      assert.strictEqual(columnFilter.doesPositionMatch('AB3'), true);
     });
     it('should match ABA57 position for ABA column', () => {
       const columnFilter = new ColumnFilter('ABA');
-      assert.equal(columnFilter.doesPositionMatch('ABA57'), true);
+      assert.strictEqual(columnFilter.doesPositionMatch('ABA57'), true);
     });
     it('should not match ABA57 position for AB column', () => {
       const columnFilter = new ColumnFilter('AB');
-      assert.equal(columnFilter.doesPositionMatch('ABA57'), false);
+      assert.strictEqual(columnFilter.doesPositionMatch('ABA57'), false);
     });
   });
   describe('#run()', () => {
@@ -47,9 +47,9 @@ describe('ColumnFilter', () => {
         ['BA13', new Cell()],
       ]);
       const filtered = columnFilter.run(cells);
-      assert.equal(filtered.has('AB12'), true);
-      assert.equal(filtered.has('AB3'), true);
-      assert.equal(filtered.has('BA13'), false);
+      assert.strictEqual(filtered.has('AB12'), true);
+      assert.strictEqual(filtered.has('AB3'), true);
+      assert.strictEqual(filtered.has('BA13'), false);
     });
   });
 });

--- a/src/tests/lib/filters/FilterGroup.test.js
+++ b/src/tests/lib/filters/FilterGroup.test.js
@@ -48,7 +48,7 @@ describe('FilterGroup', () => {
         new Map([['A4', cells.get('A4')]]),
         new Map([['A5', cells.get('A5')], ['B5', cells.get('B5')]]),
       ];
-      assert.deepEqual(result, answer);
+      assert.deepStrictEqual(result, answer);
     });
   });
 });

--- a/src/tests/lib/filters/NumberComparisonFilter.test.js
+++ b/src/tests/lib/filters/NumberComparisonFilter.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { operators, NumberComparisonFilter } from '../../../lib/filters/NumberComparisonFilter.js';
+import { NumberComparisonFilter, operators } from '../../../lib/filters/NumberComparisonFilter.js';
 import { Cell, valueTypes } from '../../../lib/spreadsheets/Cell.js';
 
 describe('NumberComparisonFilter', () => {
@@ -58,7 +58,7 @@ describe('NumberComparisonFilter', () => {
         const numberComparisonFilter = new NumberComparisonFilter(...testCase.filter);
         const cell = new Cell(...testCase.cell);
         const result = numberComparisonFilter.doesCellMatch(cell);
-        assert.equal(result, testCase.result);
+        assert.strictEqual(result, testCase.result);
       });
     });
   });

--- a/src/tests/lib/filters/RegionFilter.test.js
+++ b/src/tests/lib/filters/RegionFilter.test.js
@@ -87,7 +87,7 @@ describe('RegionFilter', () => {
         const regionFilter = new RegionFilter(...testCase.filter);
         if (!testCase.exception) {
           const result = regionFilter.doesPositionMatch(testCase.position);
-          assert.equal(result, testCase.result);
+          assert.strictEqual(result, testCase.result);
         } else {
           assert.throws(() => {
             regionFilter.doesPositionMatch(testCase.position);

--- a/src/tests/lib/filters/StringPrefixFilter.test.js
+++ b/src/tests/lib/filters/StringPrefixFilter.test.js
@@ -8,13 +8,13 @@ describe('StringPrefixFilter', () => {
       const stringPrefixFilter = new StringPrefixFilter('A', ['test']);
       const cell = new Cell(valueTypes.string, 'test123');
       const result = stringPrefixFilter.doesCellMatch(cell);
-      assert.equal(result, true);
+      assert.strictEqual(result, true);
     });
     it('should return false for "test" and "test123" filter', () => {
       const stringPrefixFilter = new StringPrefixFilter('A', ['test123']);
       const cell = new Cell(valueTypes.string, 'test');
       const result = stringPrefixFilter.doesCellMatch(cell);
-      assert.equal(result, false);
+      assert.strictEqual(result, false);
     });
     it('should return false for formula cell', () => {
       const stringPrefixFilter = new StringPrefixFilter('A', ['=1']);

--- a/src/tests/lib/filters/StringValueFilter.test.js
+++ b/src/tests/lib/filters/StringValueFilter.test.js
@@ -35,19 +35,19 @@ describe('StringValueFilter', () => {
       const stringValueFilter = new StringValueFilter('A', ['test']);
       const cell = new Cell(valueTypes.string, 'test');
       const result = stringValueFilter.doesCellMatch(cell);
-      assert.equal(result, true);
+      assert.strictEqual(result, true);
     });
     it('should return false for "test1" value and "test" filter', () => {
       const stringValueFilter = new StringValueFilter('A', ['test']);
       const cell = new Cell(valueTypes.string, 'test1');
       const result = stringValueFilter.doesCellMatch(cell);
-      assert.equal(result, false);
+      assert.strictEqual(result, false);
     });
     it('should return false for formula type', () => {
       const stringValueFilter = new StringValueFilter('A', ['test']);
       const cell = new Cell(valueTypes.formula, 'test');
       const result = stringValueFilter.doesCellMatch(cell);
-      assert.equal(result, false);
+      assert.strictEqual(result, false);
     });
   });
 });

--- a/src/tests/lib/parser/Parser.test.js
+++ b/src/tests/lib/parser/Parser.test.js
@@ -5,10 +5,10 @@ import EW from '../../../lib/parser/ExpressionWrapper.js';
 describe('Parser', () => {
   describe('#run()', () => {
     it('should parse valid values', () => {
-      assert.deepEqual(new Parser('123').run(), EW.makeClearValue('123'));
-      assert.deepEqual(new Parser('abd123efg').run(), EW.makeClearValue('abd123efg'));
-      assert.deepEqual(new Parser('=1+2+3').run(), EW.sum(EW.sum(EW.makeNumber(1), EW.makeNumber(2)), EW.makeNumber(3)));
-      assert.deepEqual(new Parser('=A1').run(), EW.makeAddress('A', 1));
+      assert.deepStrictEqual(new Parser('123').run(), EW.makeClearValue('123'));
+      assert.deepStrictEqual(new Parser('abd123efg').run(), EW.makeClearValue('abd123efg'));
+      assert.deepStrictEqual(new Parser('=1+2+3').run(), EW.sum(EW.sum(EW.makeNumber(1), EW.makeNumber(2)), EW.makeNumber(3)));
+      assert.deepStrictEqual(new Parser('=A1').run(), EW.makeAddress('A', 1));
     });
     it('should parse invalid values', () => {
       assert.throws(() => {
@@ -24,42 +24,42 @@ describe('Parser', () => {
   });
   describe('#parseBlock()', () => {
     it('should parse not function', () => {
-      assert.deepEqual(new Parser('123').run(), EW.makeClearValue('123'));
-      assert.deepEqual(new Parser('abd123efg').run(), EW.makeClearValue('abd123efg'));
+      assert.deepStrictEqual(new Parser('123').run(), EW.makeClearValue('123'));
+      assert.deepStrictEqual(new Parser('abd123efg').run(), EW.makeClearValue('abd123efg'));
     });
     it('should parse function', () => {
-      assert.deepEqual(new Parser('=1+2+3').run(), EW.sum(EW.sum(EW.makeNumber(1), EW.makeNumber(2)), EW.makeNumber(3)));
-      assert.deepEqual(new Parser('=(1+5^(1/2))/2').run(),
+      assert.deepStrictEqual(new Parser('=1+2+3').run(), EW.sum(EW.sum(EW.makeNumber(1), EW.makeNumber(2)), EW.makeNumber(3)));
+      assert.deepStrictEqual(new Parser('=(1+5^(1/2))/2').run(),
         EW.div(EW.sum(EW.makeNumber(1), EW.exp(EW.makeNumber(5),
           EW.div(EW.makeNumber(1), EW.makeNumber(2)))), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=5*(2+2)').run(), EW.mul(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=A1').run(), EW.makeAddress('A', 1));
+      assert.deepStrictEqual(new Parser('=5*(2+2)').run(), EW.mul(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=A1').run(), EW.makeAddress('A', 1));
     });
   });
   describe('#parseEquals()', () => {
     it('should parse valid logic functions (1)', () => {
-      assert.deepEqual(new Parser('=5==2+2').run(), EW.equal(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=5>=2+2').run(), EW.greaterEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=5>2+2').run(), EW.greater(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=5<=2+2').run(), EW.lessEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=5<2+2').run(), EW.less(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=5!=2+2').run(), EW.notEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5==2+2').run(), EW.equal(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5>=2+2').run(), EW.greaterEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5>2+2').run(), EW.greater(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5<=2+2').run(), EW.lessEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5<2+2').run(), EW.less(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=5!=2+2').run(), EW.notEqual(EW.makeNumber(5), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
     });
     it('should parse valid logic functions (2)', () => {
-      assert.deepEqual(new Parser('=3==2+2').run(), EW.equal(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=3>=2+2').run(), EW.greaterEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=3>2+2').run(), EW.greater(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=3<=2+2').run(), EW.lessEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=3<2+2').run(), EW.less(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=3!=2+2').run(), EW.notEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3==2+2').run(), EW.equal(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3>=2+2').run(), EW.greaterEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3>2+2').run(), EW.greater(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3<=2+2').run(), EW.lessEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3<2+2').run(), EW.less(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=3!=2+2').run(), EW.notEqual(EW.makeNumber(3), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
     });
     it('should parse valid logic functions (3)', () => {
-      assert.deepEqual(new Parser('=4==2+2').run(), EW.equal(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=4>=2+2').run(), EW.greaterEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=4>2+2').run(), EW.greater(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=4<=2+2').run(), EW.lessEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=4<2+2').run(), EW.less(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
-      assert.deepEqual(new Parser('=4!=2+2').run(), EW.notEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4==2+2').run(), EW.equal(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4>=2+2').run(), EW.greaterEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4>2+2').run(), EW.greater(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4<=2+2').run(), EW.lessEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4<2+2').run(), EW.less(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
+      assert.deepStrictEqual(new Parser('=4!=2+2').run(), EW.notEqual(EW.makeNumber(4), EW.sum(EW.makeNumber(2), EW.makeNumber(2))));
     });
     it('should parse invalid logic functions', () => {
       assert.throws(() => {
@@ -81,47 +81,47 @@ describe('Parser', () => {
   });
   describe('#parseExpr()', () => {
     it('should parse valid summarizing functions', () => {
-      assert.deepEqual(new Parser('=2+2').run(), EW.sum(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=13+27').run(), EW.sum(EW.makeNumber(13), EW.makeNumber(27)));
-      assert.deepEqual(new Parser('=436542641+23152654').run(), EW.sum(EW.makeNumber(436542641), EW.makeNumber(23152654)));
+      assert.deepStrictEqual(new Parser('=2+2').run(), EW.sum(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=13+27').run(), EW.sum(EW.makeNumber(13), EW.makeNumber(27)));
+      assert.deepStrictEqual(new Parser('=436542641+23152654').run(), EW.sum(EW.makeNumber(436542641), EW.makeNumber(23152654)));
     });
     it('should parse valid subtractive functions', () => {
-      assert.deepEqual(new Parser('=2-2').run(), EW.sub(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=13-27').run(), EW.sub(EW.makeNumber(13), EW.makeNumber(27)));
-      assert.deepEqual(new Parser('=436542641-23152654').run(), EW.sub(EW.makeNumber(436542641), EW.makeNumber(23152654)));
+      assert.deepStrictEqual(new Parser('=2-2').run(), EW.sub(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=13-27').run(), EW.sub(EW.makeNumber(13), EW.makeNumber(27)));
+      assert.deepStrictEqual(new Parser('=436542641-23152654').run(), EW.sub(EW.makeNumber(436542641), EW.makeNumber(23152654)));
     });
   });
   describe('#parseTerm()', () => {
     it('should parse valid multiplying functions', () => {
-      assert.deepEqual(new Parser('=2*2').run(), EW.mul(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=13*27').run(), EW.mul(EW.makeNumber(13), EW.makeNumber(27)));
-      assert.deepEqual(new Parser('=436542641*23152654').run(), EW.mul(EW.makeNumber(436542641), EW.makeNumber(23152654)));
+      assert.deepStrictEqual(new Parser('=2*2').run(), EW.mul(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=13*27').run(), EW.mul(EW.makeNumber(13), EW.makeNumber(27)));
+      assert.deepStrictEqual(new Parser('=436542641*23152654').run(), EW.mul(EW.makeNumber(436542641), EW.makeNumber(23152654)));
     });
     it('should parse valid dividing functions', () => {
-      assert.deepEqual(new Parser('=2/2').run(), EW.div(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=13/27').run(), EW.div(EW.makeNumber(13), EW.makeNumber(27)));
-      assert.deepEqual(new Parser('=436542641/23152654').run(), EW.div(EW.makeNumber(436542641), EW.makeNumber(23152654)));
+      assert.deepStrictEqual(new Parser('=2/2').run(), EW.div(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=13/27').run(), EW.div(EW.makeNumber(13), EW.makeNumber(27)));
+      assert.deepStrictEqual(new Parser('=436542641/23152654').run(), EW.div(EW.makeNumber(436542641), EW.makeNumber(23152654)));
     });
     it('should parse valid residual  functions', () => {
-      assert.deepEqual(new Parser('=2%2').run(), EW.rem(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=13%27').run(), EW.rem(EW.makeNumber(13), EW.makeNumber(27)));
-      assert.deepEqual(new Parser('=436542641%23152654').run(), EW.rem(EW.makeNumber(436542641), EW.makeNumber(23152654)));
+      assert.deepStrictEqual(new Parser('=2%2').run(), EW.rem(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=13%27').run(), EW.rem(EW.makeNumber(13), EW.makeNumber(27)));
+      assert.deepStrictEqual(new Parser('=436542641%23152654').run(), EW.rem(EW.makeNumber(436542641), EW.makeNumber(23152654)));
     });
   });
   describe('#parseFactor()', () => {
     it('should parse valid power functions', () => {
-      assert.deepEqual(new Parser('=2^2').run(), EW.exp(EW.makeNumber(2), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=1^1000').run(), EW.exp(EW.makeNumber(1), EW.makeNumber(1000)));
-      assert.deepEqual(new Parser('=0^1000').run(), EW.exp(EW.makeNumber(0), EW.makeNumber(1000)));
-      assert.deepEqual(new Parser('=2^10').run(), EW.exp(EW.makeNumber(2), EW.makeNumber(10)));
+      assert.deepStrictEqual(new Parser('=2^2').run(), EW.exp(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=1^1000').run(), EW.exp(EW.makeNumber(1), EW.makeNumber(1000)));
+      assert.deepStrictEqual(new Parser('=0^1000').run(), EW.exp(EW.makeNumber(0), EW.makeNumber(1000)));
+      assert.deepStrictEqual(new Parser('=2^10').run(), EW.exp(EW.makeNumber(2), EW.makeNumber(10)));
     });
   });
   describe('#parsePower() && #parseArgs()', () => {
     it('should parse valid bracket sequence', () => {
-      assert.deepEqual(new Parser('=(((1+1)+1)+1)+1').run(),
+      assert.deepStrictEqual(new Parser('=(((1+1)+1)+1)+1').run(),
         EW.sum(EW.sum(EW.sum(EW.sum(EW.makeNumber(1), EW.makeNumber(1)),
           EW.makeNumber(1)), EW.makeNumber(1)), EW.makeNumber(1)));
-      assert.deepEqual(new Parser('=((((2))+(((2)))))').run(), EW.sum(EW.makeNumber(2), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=((((2))+(((2)))))').run(), EW.sum(EW.makeNumber(2), EW.makeNumber(2)));
     });
     it('should parse invalid bracket sequence', () => {
       assert.throws(() => {
@@ -132,15 +132,15 @@ describe('Parser', () => {
       });
     });
     it('should parse valid functions with unary minus', () => {
-      assert.deepEqual(new Parser('=-1').run(), EW.unMinus(EW.makeNumber(1)));
-      assert.deepEqual(new Parser('=(-2)^3').run(), EW.exp(EW.unMinus(EW.makeNumber(2)), EW.makeNumber(3)));
-      assert.deepEqual(new Parser('=5*(-5)').run(), EW.mul(EW.makeNumber(5), EW.unMinus(EW.makeNumber(5))));
+      assert.deepStrictEqual(new Parser('=-1').run(), EW.unMinus(EW.makeNumber(1)));
+      assert.deepStrictEqual(new Parser('=(-2)^3').run(), EW.exp(EW.unMinus(EW.makeNumber(2)), EW.makeNumber(3)));
+      assert.deepStrictEqual(new Parser('=5*(-5)').run(), EW.mul(EW.makeNumber(5), EW.unMinus(EW.makeNumber(5))));
     });
     it('should parse validity function name', () => {
-      assert.deepEqual(new Parser('=СУММА(1;2)').run(), EW.makeFuncWithArgs('СУММА', EW.makeNumber(1), EW.makeNumber(2)));
-      assert.deepEqual(new Parser('=КОРЕНЬ(5)').run(), EW.makeFuncWithArgs('КОРЕНЬ', EW.makeNumber(5)));
-      assert.deepEqual(new Parser('=ЛЮБЛЮПИСАТЬТЕСТЫ()').run(), EW.makeFunc('ЛЮБЛЮПИСАТЬТЕСТЫ'));
-      assert.deepEqual(new Parser('=ИУТОП()').run(), EW.makeFunc('ИУТОП'));
+      assert.deepStrictEqual(new Parser('=СУММА(1;2)').run(), EW.makeFuncWithArgs('СУММА', EW.makeNumber(1), EW.makeNumber(2)));
+      assert.deepStrictEqual(new Parser('=КОРЕНЬ(5)').run(), EW.makeFuncWithArgs('КОРЕНЬ', EW.makeNumber(5)));
+      assert.deepStrictEqual(new Parser('=ЛЮБЛЮПИСАТЬТЕСТЫ()').run(), EW.makeFunc('ЛЮБЛЮПИСАТЬТЕСТЫ'));
+      assert.deepStrictEqual(new Parser('=ИУТОП()').run(), EW.makeFunc('ИУТОП'));
     });
     it('should parse invalidity function name', () => {
       assert.throws(() => {
@@ -162,9 +162,9 @@ describe('Parser', () => {
   });
   describe('#parseStr()', () => {
     it('should parse valid strings', () => {
-      assert.deepEqual(new Parser('="2^2"').run(), EW.makeString('2^2'));
-      assert.deepEqual(new Parser('="a"+"b"').run(), EW.sum(EW.makeString('a'), EW.makeString('b')));
-      assert.deepEqual(new Parser('="A"+1+":B"+2').run(),
+      assert.deepStrictEqual(new Parser('="2^2"').run(), EW.makeString('2^2'));
+      assert.deepStrictEqual(new Parser('="a"+"b"').run(), EW.sum(EW.makeString('a'), EW.makeString('b')));
+      assert.deepStrictEqual(new Parser('="A"+1+":B"+2').run(),
         EW.sum(EW.sum(EW.sum(EW.makeString('A'), EW.makeNumber(1)), EW.makeString(':B')), EW.makeNumber(2)));
     });
     it('should parse invalid strings', () => {
@@ -197,7 +197,7 @@ describe('Parser', () => {
       });
     });
     it('should parse valid interval', () => {
-      assert.deepEqual(new Parser('=A2:B8').run(), EW.makeInterval(EW.makeAddress('A', 2), EW.makeAddress('B', 8)));
+      assert.deepStrictEqual(new Parser('=A2:B8').run(), EW.makeInterval(EW.makeAddress('A', 2), EW.makeAddress('B', 8)));
     });
     it('should parse invalid interval', () => {
       assert.throws(() => {

--- a/src/tests/lib/spreadsheets/Workbook.test.js
+++ b/src/tests/lib/spreadsheets/Workbook.test.js
@@ -83,7 +83,7 @@ describe('Workbook', () => {
       const spreadsheet = new Spreadsheet('table', cells);
       const wb = new Workbook('book', [spreadsheet]);
 
-      assert.deepEqual(wb.getProcessedValue('A1'), (1 + Math.sqrt(5)) / 2);
+      assert.deepStrictEqual(wb.getProcessedValue('A1'), (1 + Math.sqrt(5)) / 2);
     });
     it('should take value from cell', () => {
       const cells = new Map();
@@ -91,7 +91,7 @@ describe('Workbook', () => {
       const spreadsheet = new Spreadsheet('table', cells);
       const wb = new Workbook('book', [spreadsheet]);
 
-      assert.deepEqual(wb.getProcessedValue('A1'), 23456);
+      assert.deepStrictEqual(wb.getProcessedValue('A1'), 23456);
     });
   });
 });

--- a/src/tests/lib/typevalue/BooleanType.test.js
+++ b/src/tests/lib/typevalue/BooleanType.test.js
@@ -4,8 +4,8 @@ import BT from '../../../lib/typevalue/BooleanType.js';
 describe('BooleanType', () => {
   describe('#constructor()', () => {
     it('should make new element', () => {
-      assert.deepEqual(new BT(true).value, true);
-      assert.deepEqual(new BT(false).value, false);
+      assert.deepStrictEqual(new BT(true).value, true);
+      assert.deepStrictEqual(new BT(false).value, false);
     });
   });
   describe('#makeTypeError()', () => {

--- a/src/tests/lib/typevalue/NumberType.test.js
+++ b/src/tests/lib/typevalue/NumberType.test.js
@@ -5,16 +5,16 @@ import NT from '../../../lib/typevalue/NumberType.js';
 describe('NumberType', () => {
   describe('#constructor()', () => {
     it('should make new element', () => {
-      assert.deepEqual(new NT(123).value, 123);
-      assert.deepEqual(new NT(231).value, 231);
-      assert.deepEqual(new NT(312).value, 312);
+      assert.deepStrictEqual(new NT(123).value, 123);
+      assert.deepStrictEqual(new NT(231).value, 231);
+      assert.deepStrictEqual(new NT(312).value, 312);
     });
   });
   describe('#sum()', () => {
     it('should calculate valid sum', () => {
-      assert.deepEqual(new NT(1234).sum(new NT(3245)), new NT(1234 + 3245));
-      assert.deepEqual(new NT(234).sum(new NT(2134)), new NT(234 + 2134));
-      assert.deepEqual(new NT(3).sum(new NT(4)), new NT(3 + 4));
+      assert.deepStrictEqual(new NT(1234).sum(new NT(3245)), new NT(1234 + 3245));
+      assert.deepStrictEqual(new NT(234).sum(new NT(2134)), new NT(234 + 2134));
+      assert.deepStrictEqual(new NT(3).sum(new NT(4)), new NT(3 + 4));
     });
     it('should calculate invalid sum', () => {
       assert.throws(() => {
@@ -30,9 +30,9 @@ describe('NumberType', () => {
   });
   describe('#sub()', () => {
     it('should calculate valid subtraction', () => {
-      assert.deepEqual(new NT(1234).sub(new NT(3245)), new NT(1234 - 3245));
-      assert.deepEqual(new NT(234).sub(new NT(2134)), new NT(234 - 2134));
-      assert.deepEqual(new NT(3).sub(new NT(4)), new NT(3 - 4));
+      assert.deepStrictEqual(new NT(1234).sub(new NT(3245)), new NT(1234 - 3245));
+      assert.deepStrictEqual(new NT(234).sub(new NT(2134)), new NT(234 - 2134));
+      assert.deepStrictEqual(new NT(3).sub(new NT(4)), new NT(3 - 4));
     });
     it('should calculate invalid subtraction', () => {
       assert.throws(() => {
@@ -48,9 +48,9 @@ describe('NumberType', () => {
   });
   describe('#mul()', () => {
     it('should calculate valid multiplication', () => {
-      assert.deepEqual(new NT(1234).mul(new NT(3245)), new NT(1234 * 3245));
-      assert.deepEqual(new NT(234).mul(new NT(2134)), new NT(234 * 2134));
-      assert.deepEqual(new NT(3).mul(new NT(4)), new NT(3 * 4));
+      assert.deepStrictEqual(new NT(1234).mul(new NT(3245)), new NT(1234 * 3245));
+      assert.deepStrictEqual(new NT(234).mul(new NT(2134)), new NT(234 * 2134));
+      assert.deepStrictEqual(new NT(3).mul(new NT(4)), new NT(3 * 4));
     });
     it('should calculate invalid multiplication', () => {
       assert.throws(() => {
@@ -66,9 +66,9 @@ describe('NumberType', () => {
   });
   describe('#div()', () => {
     it('should calculate valid division', () => {
-      assert.deepEqual(new NT(1234).div(new NT(3245)), new NT(1234 / 3245));
-      assert.deepEqual(new NT(234).div(new NT(2134)), new NT(234 / 2134));
-      assert.deepEqual(new NT(3).div(new NT(4)), new NT(3 / 4));
+      assert.deepStrictEqual(new NT(1234).div(new NT(3245)), new NT(1234 / 3245));
+      assert.deepStrictEqual(new NT(234).div(new NT(2134)), new NT(234 / 2134));
+      assert.deepStrictEqual(new NT(3).div(new NT(4)), new NT(3 / 4));
     });
     it('should calculate invalid division', () => {
       assert.throws(() => {
@@ -84,9 +84,9 @@ describe('NumberType', () => {
   });
   describe('#rem()', () => {
     it('should calculate valid remainder', () => {
-      assert.deepEqual(new NT(3245).rem(new NT(1234)), new NT(3245 % 1234));
-      assert.deepEqual(new NT(2134).rem(new NT(234)), new NT(2134 % 234));
-      assert.deepEqual(new NT(3).rem(new NT(4)), new NT(3 % 4));
+      assert.deepStrictEqual(new NT(3245).rem(new NT(1234)), new NT(3245 % 1234));
+      assert.deepStrictEqual(new NT(2134).rem(new NT(234)), new NT(2134 % 234));
+      assert.deepStrictEqual(new NT(3).rem(new NT(4)), new NT(3 % 4));
     });
     it('should calculate invalid remainder', () => {
       assert.throws(() => {
@@ -102,9 +102,9 @@ describe('NumberType', () => {
   });
   describe('#exp()', () => {
     it('should calculate valid exponent', () => {
-      assert.deepEqual(new NT(1234).exp(new NT(3245)), new NT(1234 ** 3245));
-      assert.deepEqual(new NT(234).exp(new NT(2134)), new NT(234 ** 2134));
-      assert.deepEqual(new NT(3).exp(new NT(4)), new NT(3 ** 4));
+      assert.deepStrictEqual(new NT(1234).exp(new NT(3245)), new NT(1234 ** 3245));
+      assert.deepStrictEqual(new NT(234).exp(new NT(2134)), new NT(234 ** 2134));
+      assert.deepStrictEqual(new NT(3).exp(new NT(4)), new NT(3 ** 4));
     });
     it('should calculate invalid exponent', () => {
       assert.throws(() => {
@@ -120,15 +120,15 @@ describe('NumberType', () => {
   });
   describe('#unMinus()', () => {
     it('should calculate unary minus', () => {
-      assert.deepEqual(new NT(1234).unMinus(), new NT(-1234));
-      assert.deepEqual(new NT(234).unMinus(), new NT(-234));
-      assert.deepEqual(new NT(3).unMinus(), new NT(-3));
+      assert.deepStrictEqual(new NT(1234).unMinus(), new NT(-1234));
+      assert.deepStrictEqual(new NT(234).unMinus(), new NT(-234));
+      assert.deepStrictEqual(new NT(3).unMinus(), new NT(-3));
     });
   });
   describe('#equal()', () => {
     it('should calculate valid equal', () => {
-      assert.deepEqual(new NT(9999).equal(new NT(0)), false);
-      assert.deepEqual(new NT(123).equal(new NT(123)), true);
+      assert.deepStrictEqual(new NT(9999).equal(new NT(0)), false);
+      assert.deepStrictEqual(new NT(123).equal(new NT(123)), true);
     });
     it('should calculate invalid equal', () => {
       assert.throws(() => {
@@ -138,8 +138,8 @@ describe('NumberType', () => {
   });
   describe('#greaterEqual()', () => {
     it('should calculate valid greater or equal', () => {
-      assert.deepEqual(new NT(9999).greaterEqual(new NT(0)), true);
-      assert.deepEqual(new NT(123).greaterEqual(new NT(123)), true);
+      assert.deepStrictEqual(new NT(9999).greaterEqual(new NT(0)), true);
+      assert.deepStrictEqual(new NT(123).greaterEqual(new NT(123)), true);
     });
     it('should calculate invalid greater or equal', () => {
       assert.throws(() => {
@@ -149,8 +149,8 @@ describe('NumberType', () => {
   });
   describe('#greater()', () => {
     it('should calculate valid greater', () => {
-      assert.deepEqual(new NT(9999).greater(new NT(0)), true);
-      assert.deepEqual(new NT(123).greater(new NT(123)), false);
+      assert.deepStrictEqual(new NT(9999).greater(new NT(0)), true);
+      assert.deepStrictEqual(new NT(123).greater(new NT(123)), false);
     });
     it('should calculate invalid greater', () => {
       assert.throws(() => {
@@ -160,8 +160,8 @@ describe('NumberType', () => {
   });
   describe('#lessEqual()', () => {
     it('should calculate valid less or equal', () => {
-      assert.deepEqual(new NT(9999).lessEqual(new NT(0)), false);
-      assert.deepEqual(new NT(123).lessEqual(new NT(123)), true);
+      assert.deepStrictEqual(new NT(9999).lessEqual(new NT(0)), false);
+      assert.deepStrictEqual(new NT(123).lessEqual(new NT(123)), true);
     });
     it('should calculate invalid less or equal', () => {
       assert.throws(() => {
@@ -171,8 +171,8 @@ describe('NumberType', () => {
   });
   describe('#less()', () => {
     it('should calculate valid less', () => {
-      assert.deepEqual(new NT(9999).less(new NT(0)), false);
-      assert.deepEqual(new NT(123).less(new NT(123)), false);
+      assert.deepStrictEqual(new NT(9999).less(new NT(0)), false);
+      assert.deepStrictEqual(new NT(123).less(new NT(123)), false);
     });
     it('should calculate invalid less', () => {
       assert.throws(() => {
@@ -182,8 +182,8 @@ describe('NumberType', () => {
   });
   describe('#notEqual()', () => {
     it('should calculate valid not equal', () => {
-      assert.deepEqual(new NT(9999).notEqual(new NT(0)), true);
-      assert.deepEqual(new NT(123).notEqual(new NT(123)), false);
+      assert.deepStrictEqual(new NT(9999).notEqual(new NT(0)), true);
+      assert.deepStrictEqual(new NT(123).notEqual(new NT(123)), false);
     });
     it('should calculate invalid not equal', () => {
       assert.throws(() => {

--- a/src/tests/lib/typevalue/StringType.test.js
+++ b/src/tests/lib/typevalue/StringType.test.js
@@ -5,16 +5,16 @@ import NT from '../../../lib/typevalue/NumberType.js';
 describe('StringType', () => {
   describe('#constructor()', () => {
     it('should make new element', () => {
-      assert.deepEqual(new ST('123').value, '123');
-      assert.deepEqual(new ST('231').value, '231');
-      assert.deepEqual(new ST('312').value, '312');
+      assert.deepStrictEqual(new ST('123').value, '123');
+      assert.deepStrictEqual(new ST('231').value, '231');
+      assert.deepStrictEqual(new ST('312').value, '312');
     });
   });
   describe('#sum()', () => {
     it('should calculate valid sum', () => {
-      assert.deepEqual(new ST('love').sum(new ST('iu')), new ST('loveiu'));
-      assert.deepEqual(new ST('231').sum(new ST('45')), new ST('23145'));
-      assert.deepEqual(new ST('312').sum(new ST('45')), new ST('31245'));
+      assert.deepStrictEqual(new ST('love').sum(new ST('iu')), new ST('loveiu'));
+      assert.deepStrictEqual(new ST('231').sum(new ST('45')), new ST('23145'));
+      assert.deepStrictEqual(new ST('312').sum(new ST('45')), new ST('31245'));
     });
     it('should calculate invalid sum', () => {
       assert.throws(() => {
@@ -30,8 +30,8 @@ describe('StringType', () => {
   });
   describe('#equal()', () => {
     it('should calculate valid equal', () => {
-      assert.deepEqual(new ST('love').equal(new ST('iu')), false);
-      assert.deepEqual(new ST('123').equal(new ST('123')), true);
+      assert.deepStrictEqual(new ST('love').equal(new ST('iu')), false);
+      assert.deepStrictEqual(new ST('123').equal(new ST('123')), true);
     });
     it('should calculate invalid equal', () => {
       assert.throws(() => {
@@ -41,8 +41,8 @@ describe('StringType', () => {
   });
   describe('#greaterEqual()', () => {
     it('should calculate valid greater or equal', () => {
-      assert.deepEqual(new ST('love').greaterEqual(new ST('iu')), true);
-      assert.deepEqual(new ST('123').greaterEqual(new ST('123')), true);
+      assert.deepStrictEqual(new ST('love').greaterEqual(new ST('iu')), true);
+      assert.deepStrictEqual(new ST('123').greaterEqual(new ST('123')), true);
     });
     it('should calculate invalid greater or equal', () => {
       assert.throws(() => {
@@ -52,8 +52,8 @@ describe('StringType', () => {
   });
   describe('#greater()', () => {
     it('should calculate valid greater', () => {
-      assert.deepEqual(new ST('love').greater(new ST('iu')), true);
-      assert.deepEqual(new ST('123').greater(new ST('123')), false);
+      assert.deepStrictEqual(new ST('love').greater(new ST('iu')), true);
+      assert.deepStrictEqual(new ST('123').greater(new ST('123')), false);
     });
     it('should calculate invalid greater', () => {
       assert.throws(() => {
@@ -63,8 +63,8 @@ describe('StringType', () => {
   });
   describe('#lessEqual()', () => {
     it('should calculate valid less or equal', () => {
-      assert.deepEqual(new ST('love').lessEqual(new ST('iu')), false);
-      assert.deepEqual(new ST('123').lessEqual(new ST('123')), true);
+      assert.deepStrictEqual(new ST('love').lessEqual(new ST('iu')), false);
+      assert.deepStrictEqual(new ST('123').lessEqual(new ST('123')), true);
     });
     it('should calculate invalid less or equal', () => {
       assert.throws(() => {
@@ -74,8 +74,8 @@ describe('StringType', () => {
   });
   describe('#less()', () => {
     it('should calculate valid less', () => {
-      assert.deepEqual(new ST('love').less(new ST('iu')), false);
-      assert.deepEqual(new ST('123').less(new ST('123')), false);
+      assert.deepStrictEqual(new ST('love').less(new ST('iu')), false);
+      assert.deepStrictEqual(new ST('123').less(new ST('123')), false);
     });
     it('should calculate invalid less', () => {
       assert.throws(() => {
@@ -85,8 +85,8 @@ describe('StringType', () => {
   });
   describe('#notEqual()', () => {
     it('should calculate valid not equal', () => {
-      assert.deepEqual(new ST('love').notEqual(new ST('iu')), true);
-      assert.deepEqual(new ST('123').notEqual(new ST('123')), false);
+      assert.deepStrictEqual(new ST('love').notEqual(new ST('iu')), true);
+      assert.deepStrictEqual(new ST('123').notEqual(new ST('123')), false);
     });
     it('should calculate invalid not equal', () => {
       assert.throws(() => {

--- a/src/tests/server/synchronizer.test.js
+++ b/src/tests/server/synchronizer.test.js
@@ -47,47 +47,49 @@ const log4 = {
   value: '=4',
 };
 describe('Synchronizer', () => {
+  beforeEach(() => {
+    mock({
+      './synchronizer': {},
+    });
+  });
+  afterEach(() => {
+    mock.restore();
+  });
   describe('#constructor()', () => {
     it('should make new element', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
-      assert.deepEqual(sz.workbook, workbook);
-      assert.deepEqual(sz.page, 0);
-      mock.restore();
+      assert.strictEqual(sz.workbook.name, workbook.name);
+      assert.strictEqual(sz.workbook.spreadsheets.length, workbook.spreadsheets.length);
+      assert.strictEqual(sz.workbook.spreadsheets[0].name, workbook.spreadsheets[0].name);
+      sz.workbook.spreadsheets[0].cells.forEach((cell, position) => {
+        const cellFromSz = cell;
+        const cellFromJSON = workbook.spreadsheets[0].cells.get(position);
+        assert.strictEqual(cellFromSz.type, cellFromJSON.type);
+        assert.strictEqual(cellFromSz.value, cellFromJSON.value);
+        assert.strictEqual(cellFromSz.color, cellFromJSON.color);
+      });
+      assert.deepStrictEqual(sz.page, 0);
     });
   });
   describe('#addArrayLogs()', () => {
     it('should add valid log (change color)', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
-      assert.deepEqual(sz.addArrayLogs([log1], 0), true);
-      assert.deepEqual(sz.workbook.spreadsheets[0]
+      assert.deepStrictEqual(sz.addArrayLogs([log1], 0), true);
+      assert.deepStrictEqual(sz.workbook.spreadsheets[0]
         .cells.get(log1.cellAddress).color, log1.color);
-      mock.restore();
     });
     it('should add valid log (change value)', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
-      assert.deepEqual(sz.addArrayLogs([log2], 0), true);
-      assert.deepEqual(sz.workbook.spreadsheets[0]
+      assert.deepStrictEqual(sz.addArrayLogs([log2], 0), true);
+      assert.deepStrictEqual(sz.workbook.spreadsheets[0]
         .cells.get(log2.cellAddress).formula, log2.formula);
-      assert.deepEqual(sz.workbook.spreadsheets[0]
+      assert.deepStrictEqual(sz.workbook.spreadsheets[0]
         .cells.get(log2.cellAddress).value, log2.value);
-      mock.restore();
     });
     it('should add invalid log', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
       assert.throws(() => {
@@ -99,38 +101,26 @@ describe('Synchronizer', () => {
       });
     });
     it('should add collision log', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
       sz.addArrayLogs([log2], 0);
-      assert.deepEqual(sz.addArrayLogs([log4], 0), [log2]);
-      mock.restore();
+      assert.deepStrictEqual(sz.addArrayLogs([log4], 0), [log2]);
     });
   });
   describe('#clearCheckChanges()', () => {
     it('should clear check changes', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
       sz.addArrayLogs([log1, log2], 0);
       sz.clearCheckChanges();
-      assert.deepEqual(sz.lastChanges, [{ ID: 0 }]);
-      mock.restore();
+      assert.deepStrictEqual(sz.lastChanges, [{ ID: 0 }]);
     });
   });
   describe('#synchronize()', () => {
     it('should synchronize', () => {
-      mock({
-        './synchronizer': {},
-      });
       ClassConverter.saveJson(workbook, './synchronizer');
       const sz = new Synchronizer('test', './synchronizer', 0);
       sz.synchronize();
-      mock.restore();
     });
   });
 });


### PR DESCRIPTION
Methods assert.equal() and assert.deepEqual were removed. TreeRunner.test.js was rewrited